### PR TITLE
Fix race condition when disabling

### DIFF
--- a/src/shouldUpdate.js
+++ b/src/shouldUpdate.js
@@ -7,8 +7,15 @@ export default function (
   const scrollDirection = currentScrollY >= lastKnownScrollY ? 'down' : 'up'
   const distanceScrolled = Math.abs(currentScrollY - lastKnownScrollY)
 
-  // We're at the top and not fixed yet.
-  if (currentScrollY <= props.pinStart && state.state !== 'unfixed') {
+  // We're disabled
+  if(props.disable) {
+    return {
+      action: 'none',
+      scrollDirection,
+      distanceScrolled,
+    }
+    // We're at the top and not fixed yet.
+  } else if (currentScrollY <= props.pinStart && state.state !== 'unfixed') {
     return {
       action: 'unfix',
       scrollDirection,


### PR DESCRIPTION
Fix a race condition where we disabled Headroom at a certain scroll point (via our app).

unFix() would be called, and the scroll listener detached, but it was called one last time, and it would compute an 'unpin' action, which would hide the navbar (exactly the opposite of what we wanted).